### PR TITLE
feat: 新增运营组，fix: review性能优化与Excel导出对接

### DIFF
--- a/app/form/api/form.api
+++ b/app/form/api/form.api
@@ -25,7 +25,7 @@ type CreateReq {
 	Grade         string `json:"grade"`
 	Gender        string `json:"gender"`
 	Phone         string `json:"phone"`
-	Group         string `json:"group,options=[Product,Design,Frontend,Backend,Android]"`
+	Group         string `json:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 	Reason        string `json:"reason"`
 	Knowledge     string `json:"knowledge"`
 	SelfIntro     string `json:"self_intro"`

--- a/app/form/api/internal/types/types.go
+++ b/app/form/api/internal/types/types.go
@@ -18,7 +18,7 @@ type CreateReq struct {
 	Grade         string `json:"grade"`
 	Gender        string `json:"gender"`
 	Phone         string `json:"phone"`
-	Group         string `json:"group,options=[Product,Design,Frontend,Backend,Android]"`
+	Group         string `json:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 	Reason        string `json:"reason"`
 	Knowledge     string `json:"knowledge"`
 	SelfIntro     string `json:"self_intro"`

--- a/app/review/cmd/api/internal/handler/routes.go
+++ b/app/review/cmd/api/internal/handler/routes.go
@@ -27,7 +27,7 @@ func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
 				Handler: SetAdmissionStatusHandler(serverCtx),
 			},
 			{
-				// 一键导出 Excel（包含每个组的名单）
+				// 一键导出 Excel（包含每个组的名单）。返回 xlsx 二进制流（application/vnd.openxmlformats-officedocument.spreadsheetml.sheet），文件名在 Content-Disposition 响应头
 				Method:  http.MethodPost,
 				Path:    "/review/export",
 				Handler: ExportReviewExcelHandler(serverCtx),

--- a/app/review/cmd/api/internal/logic/exportreviewexcellogic.go
+++ b/app/review/cmd/api/internal/logic/exportreviewexcellogic.go
@@ -56,46 +56,9 @@ func (l *ExportReviewExcelLogic) ExportReviewExcel(req *types.ExportReviewExcelR
 		startTime = time.Date(req.Year, time.January, 1, 0, 0, 0, 0, time.UTC)
 		endTime = time.Date(req.Year, time.December, 31, 23, 59, 59, 999999999, time.UTC)
 	}
-	entryForms, err := l.svcCtx.EntryFormModel.FindByGroup(l.ctx, req.Group, req.School, req.Grade, startTime, endTime)
+	rows, err := buildReviewRows(l.ctx, l.svcCtx, req.Group, req.School, req.Grade, req.Status, startTime, endTime)
 	if err != nil {
 		return nil, "", err
-	}
-	var rows []types.Row
-	for _, entryForm := range entryForms {
-
-		userId := entryForm.UserId.String()[10:34]
-		//录取进度
-		schedule, err := l.svcCtx.ScheduleClient.FindOneByUserId(l.ctx, userId)
-		if err != nil {
-			return nil, "", err
-		}
-
-		if req.Status != "" && schedule.AdmissionStatus != req.Status {
-			continue
-		}
-		//测验情况
-		userInfo, err := l.svcCtx.UserInfoModel.FindOne(l.ctx, userId)
-		if err != nil {
-			return nil, "", err
-		}
-
-		examStatus := "已提交"
-
-		rows = append(rows, types.Row{
-			Name:            userInfo.Name,
-			Grade:           entryForm.Grade,
-			School:          userInfo.School,
-			Group:           entryForm.Group,
-			Gender:          entryForm.Gender,
-			FormID:          entryForm.ID.String()[10:34],
-			ExamStuatus:     examStatus,
-			UserId:          userId,
-			AdmissionStatus: schedule.AdmissionStatus,
-			ScheduleID:      schedule.ID.String()[10:34],
-			Understanding:   entryForm.Knowledge,
-			Reason:          entryForm.Reason,
-			SelfIntro:       entryForm.SelfIntro,
-		})
 	}
 	// --- 生成 Excel ---
 	f := excelize.NewFile()

--- a/app/review/cmd/api/internal/logic/exportreviewexcellogic.go
+++ b/app/review/cmd/api/internal/logic/exportreviewexcellogic.go
@@ -4,6 +4,7 @@ import (
 	"MuXiFresh-Be-2.0/app/review/cmd/api/internal/svc"
 	"MuXiFresh-Be-2.0/app/review/cmd/api/internal/types"
 	"MuXiFresh-Be-2.0/app/user/cmd/rpc/user/userclient"
+	"MuXiFresh-Be-2.0/common/convert"
 	"MuXiFresh-Be-2.0/common/ctxData"
 	"MuXiFresh-Be-2.0/common/globalKey"
 	"bytes"
@@ -62,28 +63,64 @@ func (l *ExportReviewExcelLogic) ExportReviewExcel(req *types.ExportReviewExcelR
 	}
 	// --- 生成 Excel ---
 	f := excelize.NewFile()
-	sheet := "AllGroups"
-	f.SetSheetName("Sheet1", sheet)
 
-	headers := []string{"Name", "Grade", "School", "Group", "Gender", "FormID", "UserId", "AdmissionStatus", "ScheduleID", "Understanding", "Reason", "SelfIntro"}
-	for i, h := range headers {
-		col := string(rune('A' + i))
-		f.SetCellValue(sheet, col+"1", h)
+	groupNames := []struct{ en, cn string }{
+		{"Product", "产品组"},
+		{"Design", "设计组"},
+		{"Frontend", "前端组"},
+		{"Backend", "后端组"},
+		{"Android", "安卓组"},
+		{"Operation", "运营组"},
 	}
 
-	for rowIdx, r := range rows {
-		f.SetCellValue(sheet, "A"+strconv.Itoa(rowIdx+2), r.Name)
-		f.SetCellValue(sheet, "B"+strconv.Itoa(rowIdx+2), r.Grade)
-		f.SetCellValue(sheet, "C"+strconv.Itoa(rowIdx+2), r.School)
-		f.SetCellValue(sheet, "D"+strconv.Itoa(rowIdx+2), r.Group)
-		f.SetCellValue(sheet, "E"+strconv.Itoa(rowIdx+2), r.Gender)
-		f.SetCellValue(sheet, "F"+strconv.Itoa(rowIdx+2), r.FormID)
-		f.SetCellValue(sheet, "G"+strconv.Itoa(rowIdx+2), r.UserId)
-		f.SetCellValue(sheet, "H"+strconv.Itoa(rowIdx+2), r.AdmissionStatus)
-		f.SetCellValue(sheet, "I"+strconv.Itoa(rowIdx+2), r.ScheduleID)
-		f.SetCellValue(sheet, "J"+strconv.Itoa(rowIdx+2), r.Understanding)
-		f.SetCellValue(sheet, "K"+strconv.Itoa(rowIdx+2), r.Reason)
-		f.SetCellValue(sheet, "L"+strconv.Itoa(rowIdx+2), r.SelfIntro)
+	// 按组拆 sheet：req.Group 为空导出所有组（空组也建表头），否则仅该组
+	targets := groupNames
+	if req.Group != "" {
+		targets = nil
+		for _, g := range groupNames {
+			if g.en == req.Group {
+				targets = []struct{ en, cn string }{g}
+				break
+			}
+		}
+		if targets == nil {
+			targets = groupNames
+		}
+	}
+
+	byGroup := make(map[string][]types.Row)
+	for _, r := range rows {
+		byGroup[r.Group] = append(byGroup[r.Group], r)
+	}
+
+	headers := []string{"姓名", "年级", "学校", "组别", "性别", "专业", "电话", "报名表ID", "录取状态", "知识储备", "报名理由", "自我简介", "附加问题"}
+
+	for idx, g := range targets {
+		sheet := g.cn
+		if idx == 0 {
+			f.SetSheetName("Sheet1", sheet)
+		} else {
+			f.NewSheet(sheet)
+		}
+		for i, h := range headers {
+			f.SetCellValue(sheet, string(rune('A'+i))+"1", h)
+		}
+		for rowIdx, r := range byGroup[g.en] {
+			row := strconv.Itoa(rowIdx + 2)
+			f.SetCellValue(sheet, "A"+row, r.Name)
+			f.SetCellValue(sheet, "B"+row, r.Grade)
+			f.SetCellValue(sheet, "C"+row, r.School)
+			f.SetCellValue(sheet, "D"+row, convert.GroupCvtChinese(r.Group))
+			f.SetCellValue(sheet, "E"+row, r.Gender)
+			f.SetCellValue(sheet, "F"+row, r.Major)
+			f.SetCellValue(sheet, "G"+row, r.Phone)
+			f.SetCellValue(sheet, "H"+row, r.FormID)
+			f.SetCellValue(sheet, "I"+row, r.AdmissionStatus)
+			f.SetCellValue(sheet, "J"+row, r.Understanding)
+			f.SetCellValue(sheet, "K"+row, r.Reason)
+			f.SetCellValue(sheet, "L"+row, r.SelfIntro)
+			f.SetCellValue(sheet, "M"+row, r.ExtraQuestion)
+		}
 	}
 
 	buf, err := f.WriteToBuffer()

--- a/app/review/cmd/api/internal/logic/exportreviewexcellogic.go
+++ b/app/review/cmd/api/internal/logic/exportreviewexcellogic.go
@@ -65,7 +65,7 @@ func (l *ExportReviewExcelLogic) ExportReviewExcel(req *types.ExportReviewExcelR
 	sheet := "AllGroups"
 	f.SetSheetName("Sheet1", sheet)
 
-	headers := []string{"Name", "Grade", "School", "Group", "Gender", "FormID", "ExamStatus", "UserId", "AdmissionStatus", "ScheduleID", "Understanding", "Reason", "SelfIntro"}
+	headers := []string{"Name", "Grade", "School", "Group", "Gender", "FormID", "UserId", "AdmissionStatus", "ScheduleID", "Understanding", "Reason", "SelfIntro"}
 	for i, h := range headers {
 		col := string(rune('A' + i))
 		f.SetCellValue(sheet, col+"1", h)
@@ -78,13 +78,12 @@ func (l *ExportReviewExcelLogic) ExportReviewExcel(req *types.ExportReviewExcelR
 		f.SetCellValue(sheet, "D"+strconv.Itoa(rowIdx+2), r.Group)
 		f.SetCellValue(sheet, "E"+strconv.Itoa(rowIdx+2), r.Gender)
 		f.SetCellValue(sheet, "F"+strconv.Itoa(rowIdx+2), r.FormID)
-		f.SetCellValue(sheet, "G"+strconv.Itoa(rowIdx+2), r.ExamStuatus)
-		f.SetCellValue(sheet, "H"+strconv.Itoa(rowIdx+2), r.UserId)
-		f.SetCellValue(sheet, "I"+strconv.Itoa(rowIdx+2), r.AdmissionStatus)
-		f.SetCellValue(sheet, "J"+strconv.Itoa(rowIdx+2), r.ScheduleID)
-		f.SetCellValue(sheet, "K"+strconv.Itoa(rowIdx+2), r.Understanding)
-		f.SetCellValue(sheet, "L"+strconv.Itoa(rowIdx+2), r.Reason)
-		f.SetCellValue(sheet, "M"+strconv.Itoa(rowIdx+2), r.SelfIntro)
+		f.SetCellValue(sheet, "G"+strconv.Itoa(rowIdx+2), r.UserId)
+		f.SetCellValue(sheet, "H"+strconv.Itoa(rowIdx+2), r.AdmissionStatus)
+		f.SetCellValue(sheet, "I"+strconv.Itoa(rowIdx+2), r.ScheduleID)
+		f.SetCellValue(sheet, "J"+strconv.Itoa(rowIdx+2), r.Understanding)
+		f.SetCellValue(sheet, "K"+strconv.Itoa(rowIdx+2), r.Reason)
+		f.SetCellValue(sheet, "L"+strconv.Itoa(rowIdx+2), r.SelfIntro)
 	}
 
 	buf, err := f.WriteToBuffer()

--- a/app/review/cmd/api/internal/logic/getreviewlogic.go
+++ b/app/review/cmd/api/internal/logic/getreviewlogic.go
@@ -47,45 +47,11 @@ func (l *GetReviewLogic) GetReview(req *types.GetReviewReq) (resp *types.GetRevi
 		endTime = time.Date(req.Year, time.June, 31, 23, 59, 59, 999999999, time.UTC)
 	}
 
-	entryForms, err := l.svcCtx.EntryFormModel.FindByGroup(l.ctx, req.Group, req.School, req.Grade, startTime, endTime)
-
+	rows, err := buildReviewRows(l.ctx, l.svcCtx, req.Group, req.School, req.Grade, req.Status, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}
-	var rows []types.Row
-	for _, entryForm := range entryForms {
 
-		userId := entryForm.UserId.String()[10:34]
-		//录取进度
-		schedule, err := l.svcCtx.ScheduleClient.FindOneByUserId(l.ctx, userId)
-		if err != nil {
-			return nil, err
-		}
-
-		if req.Status != "" && schedule.AdmissionStatus != req.Status {
-			continue
-		}
-		//测验情况
-		userInfo, err := l.svcCtx.UserInfoModel.FindOne(l.ctx, userId)
-		if err != nil {
-			return nil, err
-		}
-
-		examStatus := "已提交"
-
-		rows = append(rows, types.Row{
-			Name:            userInfo.Name,
-			Grade:           entryForm.Grade,
-			School:          userInfo.School,
-			Group:           entryForm.Group,
-			Gender:          entryForm.Gender,
-			FormID:          entryForm.ID.String()[10:34],
-			ExamStuatus:     examStatus,
-			UserId:          userId,
-			AdmissionStatus: schedule.AdmissionStatus,
-			ScheduleID:      schedule.ID.String()[10:34],
-		})
-	}
 	return &types.GetReviewResp{
 		Rows: rows,
 	}, nil

--- a/app/review/cmd/api/internal/logic/getreviewlogic.go
+++ b/app/review/cmd/api/internal/logic/getreviewlogic.go
@@ -52,7 +52,26 @@ func (l *GetReviewLogic) GetReview(req *types.GetReviewReq) (resp *types.GetRevi
 		return nil, err
 	}
 
+	total := int64(len(rows))
+	// 传了 page_size 才分页；不传则全量返回，兼容旧前端
+	if req.PageSize > 0 {
+		page := req.Page
+		if page <= 0 {
+			page = 1
+		}
+		start := (page - 1) * req.PageSize
+		if start < 0 || start > total {
+			start = total
+		}
+		end := start + req.PageSize
+		if end < start || end > total {
+			end = total
+		}
+		rows = rows[start:end]
+	}
+
 	return &types.GetReviewResp{
-		Rows: rows,
+		Rows:  rows,
+		Total: total,
 	}, nil
 }

--- a/app/review/cmd/api/internal/logic/reviewrows.go
+++ b/app/review/cmd/api/internal/logic/reviewrows.go
@@ -71,14 +71,16 @@ func buildReviewRows(ctx context.Context, svcCtx *svc.ServiceContext, group, sch
 			School:          userInfo.School,
 			Group:           entryForm.Group,
 			Gender:          entryForm.Gender,
+			Major:           entryForm.Major,
+			Phone:           entryForm.Phone,
 			FormID:          entryForm.ID.Hex(),
-			ExamStuatus:     "已提交",
 			UserId:          userId,
 			AdmissionStatus: schedule.AdmissionStatus,
 			ScheduleID:      schedule.ID.Hex(),
 			Understanding:   entryForm.Knowledge,
 			Reason:          entryForm.Reason,
 			SelfIntro:       entryForm.SelfIntro,
+			ExtraQuestion:   entryForm.ExtraQuestion,
 		})
 	}
 

--- a/app/review/cmd/api/internal/logic/reviewrows.go
+++ b/app/review/cmd/api/internal/logic/reviewrows.go
@@ -1,0 +1,86 @@
+package logic
+
+import (
+	"context"
+	"time"
+
+	"MuXiFresh-Be-2.0/app/review/cmd/api/internal/svc"
+	"MuXiFresh-Be-2.0/app/review/cmd/api/internal/types"
+	scheduleModel "MuXiFresh-Be-2.0/app/schedule/model"
+	userauthModel "MuXiFresh-Be-2.0/app/userauth/model"
+
+	"github.com/zeromicro/go-zero/core/logx"
+)
+
+// buildReviewRows 查询报名表，并批量补充进度(schedule)与个人信息(userinfo)，
+// 避免逐条查询导致的 N+1 问题。缺少 schedule/userinfo 的记录会被跳过并记录日志。
+func buildReviewRows(ctx context.Context, svcCtx *svc.ServiceContext, group, school, grade, status string, startTime, endTime time.Time) ([]types.Row, error) {
+	entryForms, err := svcCtx.EntryFormModel.FindByGroup(ctx, group, school, grade, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+	if len(entryForms) == 0 {
+		return []types.Row{}, nil
+	}
+
+	userIds := make([]string, 0, len(entryForms))
+	for _, entryForm := range entryForms {
+		userIds = append(userIds, entryForm.UserId.Hex())
+	}
+
+	schedules, err := svcCtx.ScheduleClient.FindByUserIds(ctx, userIds)
+	if err != nil {
+		return nil, err
+	}
+	userInfos, err := svcCtx.UserInfoModel.FindByUserIds(ctx, userIds)
+	if err != nil {
+		return nil, err
+	}
+
+	scheduleMap := make(map[string]*scheduleModel.Schedule, len(schedules))
+	for _, schedule := range schedules {
+		scheduleMap[schedule.UserID.Hex()] = schedule
+	}
+	userInfoMap := make(map[string]*userauthModel.UserInfo, len(userInfos))
+	for _, userInfo := range userInfos {
+		userInfoMap[userInfo.ID.Hex()] = userInfo
+	}
+
+	rows := make([]types.Row, 0, len(entryForms))
+	for _, entryForm := range entryForms {
+		userId := entryForm.UserId.Hex()
+
+		schedule := scheduleMap[userId]
+		if schedule == nil {
+			logx.WithContext(ctx).Infof("buildReviewRows: missing schedule for user %s", userId)
+			continue
+		}
+		if status != "" && schedule.AdmissionStatus != status {
+			continue
+		}
+
+		userInfo := userInfoMap[userId]
+		if userInfo == nil {
+			logx.WithContext(ctx).Infof("buildReviewRows: missing userinfo for user %s", userId)
+			continue
+		}
+
+		rows = append(rows, types.Row{
+			Name:            userInfo.Name,
+			Grade:           entryForm.Grade,
+			School:          userInfo.School,
+			Group:           entryForm.Group,
+			Gender:          entryForm.Gender,
+			FormID:          entryForm.ID.Hex(),
+			ExamStuatus:     "已提交",
+			UserId:          userId,
+			AdmissionStatus: schedule.AdmissionStatus,
+			ScheduleID:      schedule.ID.Hex(),
+			Understanding:   entryForm.Knowledge,
+			Reason:          entryForm.Reason,
+			SelfIntro:       entryForm.SelfIntro,
+		})
+	}
+
+	return rows, nil
+}

--- a/app/review/cmd/api/internal/svc/index.go
+++ b/app/review/cmd/api/internal/svc/index.go
@@ -1,0 +1,96 @@
+package svc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/zeromicro/go-zero/core/logx"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// EnsureReviewIndexes 确保 review 依赖的 MongoDB 集合索引存在。
+// 索引为库级对象，任意进程建一次即可全局生效；重复执行是幂等的，
+// 已存在的索引会被识别并跳过，仅记录日志。
+func EnsureReviewIndexes(url, db string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(url))
+	if err != nil {
+		return err
+	}
+	defer client.Disconnect(context.Background())
+
+	// FindByGroup 组合过滤：createAt 恒必选且放最前，
+	// 保证所有调用至少能用 createAt 前缀做范围扫描；
+	// group/school/grade 为可选等值条件，在索引扫描后过滤。
+	if err := ensureIndex(ctx, client, db, "entry_form", "entry_form_createAt_group_school_grade",
+		bson.D{{Key: "createAt", Value: 1}, {Key: "group", Value: 1},
+			{Key: "school", Value: 1}, {Key: "grade", Value: 1}}); err != nil {
+		return err
+	}
+
+	// FindByUserIds / FindOneByUserId 的 $in 与单条查询
+	return ensureIndex(ctx, client, db, "schedule", "schedule_user_id",
+		bson.D{{Key: "user_id", Value: 1}})
+}
+
+func ensureIndex(ctx context.Context, client *mongo.Client, db, collection, name string, keys bson.D) error {
+	coll := client.Database(db).Collection(collection)
+
+	exists, err := indexExists(ctx, coll, name)
+	if err != nil {
+		return fmt.Errorf("list index %s: %w", name, err)
+	}
+	if exists {
+		logx.Infof("index %s already exists, skip", name)
+		return nil
+	}
+
+	_, err = coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    keys,
+		Options: options.Index().SetName(name),
+	})
+	if err != nil {
+		if isIndexExists(err) {
+			logx.Infof("index %s already exists, skip", name)
+			return nil
+		}
+		return fmt.Errorf("create index %s: %w", name, err)
+	}
+	logx.Infof("index %s created", name)
+	return nil
+}
+
+// indexExists 遍历集合索引，判断指定名称的索引是否已存在。
+func indexExists(ctx context.Context, coll *mongo.Collection, name string) (bool, error) {
+	cur, err := coll.Indexes().List(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer cur.Close(ctx)
+
+	for cur.Next(ctx) {
+		var idx bson.M
+		if err := cur.Decode(&idx); err != nil {
+			return false, err
+		}
+		if idx["name"] == name {
+			return true, nil
+		}
+	}
+	return false, cur.Err()
+}
+
+func isIndexExists(err error) bool {
+	var se mongo.ServerError
+	if errors.As(err, &se) {
+		// 48 NamespaceExists, 85 IndexOptionsConflict, 86 IndexKeySpecsConflict
+		return se.HasErrorCode(48) || se.HasErrorCode(85) || se.HasErrorCode(86)
+	}
+	return false
+}

--- a/app/review/cmd/api/internal/svc/servicecontext.go
+++ b/app/review/cmd/api/internal/svc/servicecontext.go
@@ -6,6 +6,7 @@ import (
 	externalModel3 "MuXiFresh-Be-2.0/app/schedule/model"
 	"MuXiFresh-Be-2.0/app/user/cmd/rpc/user/userclient"
 	externalModel1 "MuXiFresh-Be-2.0/app/userauth/model"
+	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/zrpc"
 )
 
@@ -18,6 +19,10 @@ type ServiceContext struct {
 }
 
 func NewServiceContext(c config.Config) *ServiceContext {
+	if err := EnsureReviewIndexes(c.Infra.MongoDB.URL, c.Infra.MongoDB.DB); err != nil {
+		logx.Errorf("EnsureReviewIndexes failed: %v", err)
+	}
+
 	return &ServiceContext{
 		Config:         c,
 		EntryFormModel: externalModel2.NewEntryFormModel(c.Infra.MongoDB.URL, c.Infra.MongoDB.DB, "entry_form"),

--- a/app/review/cmd/api/internal/types/types.go
+++ b/app/review/cmd/api/internal/types/types.go
@@ -21,10 +21,13 @@ type GetReviewReq struct {
 	Grade         string `json:"grade,optional"`
 	School        string `json:"school,optional"`
 	Status        string `json:"status,optional"`
+	Page          int64  `json:"page,optional,default=1"`
+	PageSize      int64  `json:"page_size,optional"`
 }
 
 type GetReviewResp struct {
-	Rows []Row `json:"rows"`
+	Rows  []Row `json:"rows"`
+	Total int64 `json:"total"`
 }
 
 type Row struct {

--- a/app/review/cmd/api/internal/types/types.go
+++ b/app/review/cmd/api/internal/types/types.go
@@ -7,7 +7,7 @@ type ExportReviewExcelReq struct {
 	Authorization string `header:"Authorization"`
 	Year          int    `json:"year"`
 	Season        string `json:"season,options=[autumn,spring]"`
-	Group         string `json:"group,optional"` // 如果为空，导出所有组
+	Group         string `json:"group,optional,options=[Product,Design,Frontend,Backend,Android,Operation]"` // 如果为空，导出所有组
 	Grade         string `json:"grade,optional"`
 	School        string `json:"school,optional"`
 	Status        string `json:"status,optional"`
@@ -16,7 +16,7 @@ type ExportReviewExcelReq struct {
 type GetReviewReq struct {
 	Authorization string `header:"Authorization"`
 	Year          int    `json:"year"`
-	Group         string `json:"group"`
+	Group         string `json:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 	Season        string `json:"season,options=[autumn,spring]"`
 	Grade         string `json:"grade,optional"`
 	School        string `json:"school,optional"`

--- a/app/review/cmd/api/internal/types/types.go
+++ b/app/review/cmd/api/internal/types/types.go
@@ -36,14 +36,16 @@ type Row struct {
 	School          string `json:"school"`
 	Group           string `json:"group"`
 	Gender          string `json:"gender"`
+	Major           string `json:"major"`
+	Phone           string `json:"phone"`
 	FormID          string `json:"form_id"`
-	ExamStuatus     string `json:"exam_status"`
 	UserId          string `json:"user_id"`
 	AdmissionStatus string `json:"admission_status"`
 	ScheduleID      string `json:"schedule_id"`
 	Understanding   string `json:"understanding"`
 	Reason          string `json:"reason"`
 	SelfIntro       string `json:"selfintro"`
+	ExtraQuestion   string `json:"extra_question"`
 }
 
 type SetAdmissionStatusReq struct {

--- a/app/review/cmd/api/review.api
+++ b/app/review/cmd/api/review.api
@@ -26,14 +26,16 @@ type Row {
 	School          string `json:"school"`
 	Group           string `json:"group"`
 	Gender          string `json:"gender"`
+	Major           string `json:"major"`
+	Phone           string `json:"phone"`
 	FormID          string `json:"form_id"`
-	ExamStuatus     string `json:"exam_status"`
 	UserId          string `json:"user_id"`
 	AdmissionStatus string `json:"admission_status"`
 	ScheduleID      string `json:"schedule_id"`
 	Understanding   string `json:"understanding"`
 	Reason          string `json:"reason"`
 	SelfIntro       string `json:"selfintro"`
+	ExtraQuestion   string `json:"extra_question"`
 }
 
 type GetReviewResp {

--- a/app/review/cmd/api/review.api
+++ b/app/review/cmd/api/review.api
@@ -78,7 +78,7 @@ service review {
 	@handler SetAdmissionStatus
 	post /review/admission_status (SetAdmissionStatusReq) returns (SetAdmissionStatusResp)
 
-	@doc "一键导出 Excel（包含每个组的名单）"
+	@doc "一键导出 Excel（包含每个组的名单）。返回 xlsx 二进制流（application/vnd.openxmlformats-officedocument.spreadsheetml.sheet），文件名在 Content-Disposition 响应头"
 	@handler ExportReviewExcel
 	post /review/export (ExportReviewExcelReq)
 }

--- a/app/review/cmd/api/review.api
+++ b/app/review/cmd/api/review.api
@@ -16,6 +16,8 @@ type GetReviewReq {
 	Grade         string `json:"grade,optional"`
 	School        string `json:"school,optional"`
 	Status        string `json:"status,optional"`
+	Page          int64  `json:"page,optional,default=1"`
+	PageSize      int64  `json:"page_size,optional"`
 }
 
 type Row {
@@ -35,7 +37,8 @@ type Row {
 }
 
 type GetReviewResp {
-	Rows []Row `json:"rows"`
+	Rows  []Row `json:"rows"`
+	Total int64 `json:"total"`
 }
 
 //调整录取状态

--- a/app/review/cmd/api/review.api
+++ b/app/review/cmd/api/review.api
@@ -11,7 +11,7 @@ info (
 type GetReviewReq {
 	Authorization string `header:"Authorization"`
 	Year          int    `json:"year"`
-	Group         string `json:"group"`
+	Group         string `json:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 	Season        string `json:"season,options=[autumn,spring]"`
 	Grade         string `json:"grade,optional"`
 	School        string `json:"school,optional"`
@@ -59,7 +59,7 @@ type ExportReviewExcelReq {
 	Authorization string `header:"Authorization"`
 	Year          int    `json:"year"`
 	Season        string `json:"season,options=[autumn,spring]"`
-	Group         string `json:"group,optional"` // 如果为空，导出所有组
+	Group         string `json:"group,optional,options=[Product,Design,Frontend,Backend,Android,Operation]"` // 如果为空，导出所有组
 	Grade         string `json:"grade,optional"`
 	School        string `json:"school,optional"`
 	Status        string `json:"status,optional"`

--- a/app/schedule/model/schedulemodel.go
+++ b/app/schedule/model/schedulemodel.go
@@ -18,6 +18,7 @@ type (
 	ScheduleModel interface {
 		scheduleModel
 		FindOneByUserId(ctx context.Context, userId string) (*Schedule, error)
+		FindByUserIds(ctx context.Context, userIds []string) ([]*Schedule, error)
 		UpdateByUserId(ctx context.Context, data *Schedule) (*mongo.UpdateResult, error)
 		InsertGetID(ctx context.Context, data *Schedule) (string, error)
 	}
@@ -47,6 +48,28 @@ func (m *customScheduleModel) FindOneByUserId(ctx context.Context, userId string
 	switch err {
 	case nil:
 		return &data, nil
+	case mon.ErrNotFound:
+		return nil, ErrNotFound
+	default:
+		return nil, err
+	}
+}
+
+func (m *customScheduleModel) FindByUserIds(ctx context.Context, userIds []string) ([]*Schedule, error) {
+	oids := make([]primitive.ObjectID, 0, len(userIds))
+	for _, id := range userIds {
+		oid, err := primitive.ObjectIDFromHex(id)
+		if err != nil {
+			return nil, ErrInvalidObjectId
+		}
+		oids = append(oids, oid)
+	}
+
+	var schedules []*Schedule
+	err := m.conn.Find(ctx, &schedules, bson.M{"user_id": bson.M{"$in": oids}})
+	switch err {
+	case nil:
+		return schedules, nil
 	case mon.ErrNotFound:
 		return nil, ErrNotFound
 	default:

--- a/app/task/cmd/api/internal/types/types.go
+++ b/app/task/cmd/api/internal/types/types.go
@@ -69,7 +69,7 @@ type GetAssignmentInfoResp struct {
 
 type GetAssignmentListReq struct {
 	Authorization string `header:"Authorization"`
-	Group         string `form:"group,options=[Product,Design,Frontend,Backend,Android]"`
+	Group         string `form:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 }
 
 type GetAssignmentListResp struct {
@@ -78,7 +78,7 @@ type GetAssignmentListResp struct {
 
 type GetAssignmentListSelectedReq struct {
 	Authorization string `header:"Authorization"`
-	Group         string `form:"group,options=[Product,Design,Frontend,Backend,Android]"`
+	Group         string `form:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 	Year          int    `form:"year"`
 	Semester      string `form:"semester,options=[autumn,spring]"`
 }
@@ -129,7 +129,7 @@ type ReplySubmissionCommentResp struct {
 type SetAssignmentReq struct {
 	Authorization string   `header:"Authorization"`
 	AssignmentID  string   `json:"assignedTaskID,optional"`
-	Group         string   `form:"group,options=[Product,Design,Frontend,Backend,Android]"`
+	Group         string   `form:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 	TitleText     string   `json:"title_text"`
 	Content       string   `json:"content"`
 	Urls          []string `json:"urls"`

--- a/app/task/cmd/api/task.api
+++ b/app/task/cmd/api/task.api
@@ -71,7 +71,7 @@ type (
 type (
 	GetAssignmentListReq {
 		Authorization string `header:"Authorization"`
-		Group         string `form:"group,options=[Product,Design,Frontend,Backend,Android]"`
+		Group         string `form:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 	}
 	Title {
 		ID   string `json:"id"`
@@ -86,7 +86,7 @@ type (
 type (
 	GetAssignmentListSelectedReq {
 		Authorization string `header:"Authorization"`
-		Group         string `form:"group,options=[Product,Design,Frontend,Backend,Android]"`
+		Group         string `form:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 		Year          int    `form:"year"`
 		Semester      string `form:"semester,options=[autumn,spring]"`
 	}
@@ -116,7 +116,7 @@ type (
 	SetAssignmentReq {
 		Authorization string   `header:"Authorization"`
 		AssignmentID  string   `json:"assignedTaskID,optional"`
-		Group         string   `form:"group,options=[Product,Design,Frontend,Backend,Android]"`
+		Group         string   `form:"group,options=[Product,Design,Frontend,Backend,Android,Operation]"`
 		TitleText     string   `json:"title_text"`
 		Content       string   `json:"content"`
 		Urls          []string `json:"urls"`

--- a/app/userauth/model/userinfomodel.go
+++ b/app/userauth/model/userinfomodel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/zeromicro/go-zero/core/stores/mon"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"time"
@@ -17,6 +18,7 @@ type (
 	UserInfoModel interface {
 		userInfoModel
 		FindByStudentID(ctx context.Context, studentID string) (*UserInfo, error)
+		FindByUserIds(ctx context.Context, userIds []string) ([]*UserInfo, error)
 		UpdateByEmail(ctx context.Context, data *UserInfo) (*mongo.UpdateResult, error)
 		FindByUserType(ctx context.Context, userType string) ([]*UserInfo, error)
 	}
@@ -41,6 +43,28 @@ func (m *defaultUserInfoModel) FindByStudentID(ctx context.Context, studentID st
 	switch err {
 	case nil:
 		return &data, nil
+	case mon.ErrNotFound:
+		return nil, ErrNotFound
+	default:
+		return nil, err
+	}
+}
+
+func (m *customUserInfoModel) FindByUserIds(ctx context.Context, userIds []string) ([]*UserInfo, error) {
+	oids := make([]primitive.ObjectID, 0, len(userIds))
+	for _, id := range userIds {
+		oid, err := primitive.ObjectIDFromHex(id)
+		if err != nil {
+			return nil, ErrInvalidObjectId
+		}
+		oids = append(oids, oid)
+	}
+
+	var userInfos []*UserInfo
+	err := m.conn.Find(ctx, &userInfos, bson.M{"_id": bson.M{"$in": oids}})
+	switch err {
+	case nil:
+		return userInfos, nil
 	case mon.ErrNotFound:
 		return nil, ErrNotFound
 	default:

--- a/common/convert/convert.go
+++ b/common/convert/convert.go
@@ -14,6 +14,8 @@ func GroupCvtChinese(group string) string {
 		group = "安卓组"
 	case "Frontend":
 		group = "前端组"
+	case "Operation":
+		group = "运营组"
 	}
 	return group
 }


### PR DESCRIPTION
# Description

## Summary

新增「运营组」，并修复招新系统交接文档中的两个已知问题（Review 列表查询超时、Excel 导出未完成对接）。

## Changes

### 新增运营组

- 组别值 `Operation`，白名单 `options` 追加（form.api / task.api + 生成 types.go）
- `GroupCvtChinese` 增加中文映射「运营组」

### Review 列表超时修复

- 批量查询消除 N+1：新增 `FindByUserIds`（$in）+ 公共函数 `buildReviewRows`，查询次数 1+2N -> 3
- 启动时自动建 MongoDB 索引（entry_form 组合索引 + schedule.user_id，幂等）
- 接口分页：`page/page_size` 可选（向后兼容）+ 返回 `total`
- status 过滤：schedule 批量查询后录取状态判断变为内存操作、代价趋零，保持现状、不做前置聚合（entry_form 查询无法提前带 schedule 的 status 条件，属跨集合限制，收益几乎趋近于零）

### Excel 导出对接

- 按组拆 sheet（6 组，空组保留表头）
- 中文表头、字段口径整理（剔除 UserId/ScheduleID/exam_status，补充 major/phone/extra_question）
- 空数据导出空表不报错
- group 字段加白名单校验
- 接口 API 描述补充：返回 xlsx 二进制流、文件名在 Content-Disposition 响应头

## Notes / Follow-up

- task 两处也有 N+1（getAllSubmissionStatus、getSubmissionComment）待后续考虑可以重构？
- `entry_form` 无 School 字段但 `FindByGroup` 按 school 过滤（恒为空），之后可以考虑清理？
- 组别列表存在三处硬编码，未来加组仍需同步（groupNames / GroupCvtChinese / globalKey），或许可以根据实际考虑提到全局编码？

## Testing

- `go build ./...` 通过（Windows 全量构建需 `-p 1`）
- 索引创建与幂等、批量查询（$in）、Excel 导出生成已用本地 Docker MongoDB 集成测试验证通过
- 未做完整服务端到端联调，分页/导出与前端交互建议联调环境确认

## 前端对接

关于与前端对接，待review没大问题了我到时候再写对接文档给前端