### PR TITLE
fix: etcd客户端注册认证账号

### DIFF
--- a/common/infra/config.go
+++ b/common/infra/config.go
@@ -56,6 +56,13 @@ type ObjectStorageConf struct {
 }
 
 func (c Config) ApplyEtcd(targets ...*discov.EtcdConf) {
+	// go-zero's etcd client does not automatically use the User/Pass in config;
+	// must call RegisterAccount explicitly, otherwise connecting to an
+	// authenticated etcd fails with "user name is empty".
+	if c.Etcd.User != "" && c.Etcd.Pass != "" {
+		discov.RegisterAccount(c.Etcd.Hosts, c.Etcd.User, c.Etcd.Pass)
+	}
+
 	for _, target := range targets {
 		if target == nil {
 			continue


### PR DESCRIPTION
## Description

### Summary

修复进度查询等跨服务接口的 `zero addresses`：etcd 启用认证后，go-zero 客户端发现链路未注册账号，导致 `user name is empty`、服务发现失败。

### 原因

- go-zero（v1.4.5）的 etcd **客户端发现不自带认证**，必须显式 `discov.RegisterAccount` 注册账号
- 项目 `common/infra/config.go` 仅把 User/Pass 写入配置结构，从未调用 `RegisterAccount`
- etcd 启用认证后，所有服务的发现请求无认证被拒 → 找不到服务 → `zero addresses`

### 修复

`common/infra/config.go` 的 `ApplyEtcd` 中，当 infra 配置了 Etcd User/Pass 时，显式调用 `discov.RegisterAccount`（所有服务走该公共方法，一处生效）。

### 验证

- `go build` 通过
- 需**全量部署**（RegisterAccount 为进程级），部署后确认服务 key 正常注册、接口不再 `zero addresses`