### PR TITLE
fix: 报名流程创建schedule并关联userinfo + schedule唯一索引

### DIFF
--- a/app/form/api/internal/logic/createformlogic.go
+++ b/app/form/api/internal/logic/createformlogic.go
@@ -7,6 +7,7 @@ import (
 	"MuXiFresh-Be-2.0/common/ctxData"
 	"context"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"time"
 
 	"MuXiFresh-Be-2.0/app/form/api/internal/svc"
@@ -56,35 +57,23 @@ func (l *CreateFormLogic) CreateForm(req *types.CreateReq) (resp *types.CreateRe
 		return nil, err
 	}
 
-	// 创建或更新 schedule：确保用户存在 schedule 文档，
-	// 否则 UpdateByUserId 对不存在的文档静默无效，导致进度/my-info 缺失关联。
-	var scheduleID string
-	existingSchedule, sErr := l.svcCtx.ScheduleModel.FindOneByUserId(l.ctx, userId)
-	switch sErr {
-	case nil:
-		scheduleID = existingSchedule.ID.String()[10:34]
-		_, err = l.svcCtx.ScheduleModel.UpdateByUserId(l.ctx, &schedulemodel.Schedule{
-			UserID:          u,
-			EntryFormStatus: "已提交",
-			AdmissionStatus: "已报名",
-		})
-	case schedulemodel.ErrNotFound:
-		scheduleID, err = l.svcCtx.ScheduleModel.InsertGetID(l.ctx, &schedulemodel.Schedule{
-			UserID:          u,
-			EntryFormStatus: "已提交",
-			AdmissionStatus: "已报名",
-		})
-	default:
-		return nil, sErr
-	}
-	if err != nil {
+	// 原子 upsert schedule：不存在则创建、存在则更新（配合 user_id 唯一索引防并发双写）。
+	// 唯一索引冲突（并发双击）时 DuplicateKey 视为已创建，继续走后续关联。
+	_, err = l.svcCtx.ScheduleModel.UpsertByUserId(l.ctx, &schedulemodel.Schedule{
+		UserID:          u,
+		EntryFormStatus: "已提交",
+		AdmissionStatus: "已报名",
+	})
+	if err != nil && !mongo.IsDuplicateKeyError(err) {
 		return nil, err
 	}
 
-	sid, err := primitive.ObjectIDFromHex(scheduleID[10:34])
+	// upsert 后查一次拿 scheduleID，写入 userinfo 关联
+	schedule, err := l.svcCtx.ScheduleModel.FindOneByUserId(l.ctx, userId)
 	if err != nil {
 		return nil, err
 	}
+	sid := schedule.ID
 	_, err = l.svcCtx.UserInfoModelClient.Update(l.ctx, &externalModel.UserInfo{
 		ID:          u,
 		EntryFormID: f,

--- a/app/form/api/internal/logic/createformlogic.go
+++ b/app/form/api/internal/logic/createformlogic.go
@@ -56,18 +56,40 @@ func (l *CreateFormLogic) CreateForm(req *types.CreateReq) (resp *types.CreateRe
 		return nil, err
 	}
 
-	_, err = l.svcCtx.UserInfoModelClient.Update(l.ctx, &externalModel.UserInfo{
-		ID:          u,
-		EntryFormID: f,
-		UpdateAt:    time.Now(),
-	})
+	// 创建或更新 schedule：确保用户存在 schedule 文档，
+	// 否则 UpdateByUserId 对不存在的文档静默无效，导致进度/my-info 缺失关联。
+	var scheduleID string
+	existingSchedule, sErr := l.svcCtx.ScheduleModel.FindOneByUserId(l.ctx, userId)
+	switch sErr {
+	case nil:
+		scheduleID = existingSchedule.ID.String()[10:34]
+		_, err = l.svcCtx.ScheduleModel.UpdateByUserId(l.ctx, &schedulemodel.Schedule{
+			UserID:          u,
+			EntryFormStatus: "已提交",
+			AdmissionStatus: "已报名",
+		})
+	case schedulemodel.ErrNotFound:
+		scheduleID, err = l.svcCtx.ScheduleModel.InsertGetID(l.ctx, &schedulemodel.Schedule{
+			UserID:          u,
+			EntryFormStatus: "已提交",
+			AdmissionStatus: "已报名",
+		})
+	default:
+		return nil, sErr
+	}
 	if err != nil {
 		return nil, err
 	}
-	_, err = l.svcCtx.ScheduleModel.UpdateByUserId(l.ctx, &schedulemodel.Schedule{
-		UserID:          u,
-		EntryFormStatus: "已提交",
-		AdmissionStatus: "已报名",
+
+	sid, err := primitive.ObjectIDFromHex(scheduleID[10:34])
+	if err != nil {
+		return nil, err
+	}
+	_, err = l.svcCtx.UserInfoModelClient.Update(l.ctx, &externalModel.UserInfo{
+		ID:          u,
+		EntryFormID: f,
+		ScheduleID:  sid,
+		UpdateAt:    time.Now(),
 	})
 	if err != nil {
 		return nil, err

--- a/app/review/cmd/api/internal/svc/index.go
+++ b/app/review/cmd/api/internal/svc/index.go
@@ -28,18 +28,21 @@ func EnsureReviewIndexes(url, db string) error {
 	// FindByGroup 组合过滤：createAt 恒必选且放最前，
 	// 保证所有调用至少能用 createAt 前缀做范围扫描；
 	// group/school/grade 为可选等值条件，在索引扫描后过滤。
-	if err := ensureIndex(ctx, client, db, "entry_form", "entry_form_createAt_group_school_grade",
+	if err := ensureIndex(ctx, client, db, "entry_form", "entry_form_createAt_group_school_grade", false,
 		bson.D{{Key: "createAt", Value: 1}, {Key: "group", Value: 1},
 			{Key: "school", Value: 1}, {Key: "grade", Value: 1}}); err != nil {
 		return err
 	}
 
-	// FindByUserIds / FindOneByUserId 的 $in 与单条查询
-	return ensureIndex(ctx, client, db, "schedule", "schedule_user_id",
+	// FindByUserIds / FindOneByUserId 的 $in 与单条查询；
+	// user_id 唯一索引用于兜底 schedule 并发双写（配合 UpsertByUserId）。
+	// 注意：若数据库已存在同名的非唯一 schedule_user_id，需先 drop 旧索引，
+	// 否则 unique 索引不会建上（indexExists 按名命中后跳过）。
+	return ensureIndex(ctx, client, db, "schedule", "schedule_user_id", true,
 		bson.D{{Key: "user_id", Value: 1}})
 }
 
-func ensureIndex(ctx context.Context, client *mongo.Client, db, collection, name string, keys bson.D) error {
+func ensureIndex(ctx context.Context, client *mongo.Client, db, collection, name string, unique bool, keys bson.D) error {
 	coll := client.Database(db).Collection(collection)
 
 	exists, err := indexExists(ctx, coll, name)
@@ -51,9 +54,14 @@ func ensureIndex(ctx context.Context, client *mongo.Client, db, collection, name
 		return nil
 	}
 
+	opts := options.Index().SetName(name)
+	if unique {
+		opts = opts.SetUnique(true)
+	}
+
 	_, err = coll.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    keys,
-		Options: options.Index().SetName(name),
+		Options: opts,
 	})
 	if err != nil {
 		if isIndexExists(err) {

--- a/app/schedule/model/schedulemodel.go
+++ b/app/schedule/model/schedulemodel.go
@@ -7,6 +7,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"time"
 )
 
@@ -20,6 +21,7 @@ type (
 		FindOneByUserId(ctx context.Context, userId string) (*Schedule, error)
 		FindByUserIds(ctx context.Context, userIds []string) ([]*Schedule, error)
 		UpdateByUserId(ctx context.Context, data *Schedule) (*mongo.UpdateResult, error)
+		UpsertByUserId(ctx context.Context, data *Schedule) (*mongo.UpdateResult, error)
 		InsertGetID(ctx context.Context, data *Schedule) (string, error)
 	}
 
@@ -81,6 +83,28 @@ func (m *defaultScheduleModel) UpdateByUserId(ctx context.Context, data *Schedul
 	data.UpdateAt = time.Now()
 
 	res, err := m.conn.UpdateOne(ctx, bson.M{"user_id": data.UserID}, bson.M{"$set": data})
+	return res, err
+}
+
+// UpsertByUserId 原子地按 user_id 插入或更新 schedule，
+// 配合 user_id 唯一索引可避免并发下的双写（需在 MongoDB 建 unique 索引）。
+// 更新只刷新状态与 updateAt，createAt/user_id 仅插入时写入（$setOnInsert）。
+func (m *defaultScheduleModel) UpsertByUserId(ctx context.Context, data *Schedule) (*mongo.UpdateResult, error) {
+	now := time.Now()
+
+	res, err := m.conn.UpdateOne(ctx, bson.M{"user_id": data.UserID},
+		bson.M{
+			"$set": bson.M{
+				"entry_form_status": data.EntryFormStatus,
+				"admission_status":  data.AdmissionStatus,
+				"updateAt":          now,
+			},
+			"$setOnInsert": bson.M{
+				"user_id":  data.UserID,
+				"createAt": now,
+			},
+		},
+		options.Update().SetUpsert(true))
 	return res, err
 }
 


### PR DESCRIPTION
## Description

### Summary

修复报名流程导致的"信息破碎"：首次报名且此前无 schedule 文档的用户，schedule 永远缺失、`userinfo.schedule_id` 为全 0，引发 `/users/my-info`、进度查询 `mongo: no documents`，前端 home 页 `userInfo.name` 崩溃。

### 原因

- `createformlogic.go` 用 `UpdateByUserId`（**非 upsert**）更新 schedule，schedule 不存在时静默无效
- userinfo 更新时**不写 ScheduleID** → 关联全 0
- 后端 `my-info`/进度查询均从 `userinfo.ScheduleID` 查 schedule → 全 0 → `no documents`

### 修复

1. **报名流程原子 upsert schedule**（`UpsertByUserId`：不存在创建、存在更新），并写入 `userinfo.ScheduleID` 关联
2. upsert 用 `$setOnInsert` 保护 createAt、兼容并发 DuplicateKey
3. **`schedule.user_id` 唯一索引**：数据库层兜底防并发双写

### 运维措施

- 前置查重（无重复 user_id）：
  `db.schedule.aggregate([{$group: {_id: "$user_id", count: {$sum: 1}}}, {$match: {count: {$gt: 1}}}])` → 空
- 建唯一索引（已执行成功）：
  `db.schedule.createIndex({ user_id: 1 }, { unique: true })` → `user_id_1`

### 验证

- `go build` 通过（form/schedule）
- 数据库唯一索引 `user_id_1` 已建成功